### PR TITLE
Port is now also in the directory name

### DIFF
--- a/core/streaming/processor.go
+++ b/core/streaming/processor.go
@@ -180,7 +180,7 @@ func GetURIDirectory(URI string) (string, error) {
 	if err = ValidateURL(URL); err != nil {
 		return "", err
 	}
-	return sanitize.BaseName(fmt.Sprintf("%s-%s", URL.Hostname(), sanitize.Path(URL.Path))), nil
+	return sanitize.BaseName(fmt.Sprintf("%s-%s-%s", URL.Hostname(), URL.Port(), sanitize.Path(URL.Path))), nil
 }
 
 // createDirectoryForURI is to create a safe path based on the received URI


### PR DESCRIPTION
* Added port to the storage directory name because the service was not able to distinguish between different ports on the same host. 