### PR TITLE
feat: preloaded sources and stream aliases, loaded on demand

### DIFF
--- a/build/rtsp-stream.yml
+++ b/build/rtsp-stream.yml
@@ -12,7 +12,7 @@ endpoints:
     secret: macilaci
 
 listen:
-  - id: sample
+  - alias: sample
     uri: rtsp://user:pass@host/Streaming/Channels/123/
     enabled: false
 

--- a/build/rtsp-stream.yml
+++ b/build/rtsp-stream.yml
@@ -10,3 +10,9 @@ endpoints:
   list:
     enabled: true
     secret: macilaci
+
+listen:
+  - id: sample
+    uri: rtsp://user:pass@host/Streaming/Channels/123/
+    enabled: false
+

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -75,7 +75,7 @@ type EndpointSetting struct {
 type ListenSetting struct {
 	Enabled        bool          `yaml:"enabled"`
 	Uri    		   string 		 `yaml:"uri"`
-	Name           string        `yaml:"name"`
+	Alias          string        `yaml:"alias"`
 }
 
 // EndpointYML describes the yml structure used

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -72,6 +72,12 @@ type EndpointSetting struct {
 	Secret  string `yml:"secret"`
 }
 
+type ListenSetting struct {
+	Enabled        bool          `yaml:"enabled"`
+	Uri    		   string 		 `yaml:"uri"`
+	Name           string        `yaml:"name"`
+}
+
 // EndpointYML describes the yml structure used
 type EndpointYML struct {
 	Version   string `yaml:"version"`
@@ -81,6 +87,7 @@ type EndpointYML struct {
 		List   EndpointSetting `yaml:"list"`
 		Static EndpointSetting `yaml:"static"`
 	} `yaml:"endpoints"`
+	Listen [] ListenSetting `yaml:"listen"`
 }
 
 // InitConfig is to initalise the config

--- a/core/controller.go
+++ b/core/controller.go
@@ -243,14 +243,15 @@ func (c *Controller) ListStreamHandler(w http.ResponseWriter, r *http.Request, _
 	// active streams
 	for key, stream := range c.streams {
 		aliasName := ""
+		newKey := key
 		for name, id := range c.alias {
 			if id == stream.ID {
 				aliasName = name
-				key = name
+				newKey = name
 			}
 		}
 		dto = append(dto, &SummariseDTO{
-			URI:     fmt.Sprintf("/stream/%s/index.m3u8", key),
+			URI:     fmt.Sprintf("/stream/%s/index.m3u8", newKey),
 			Running: stream.Streak.IsActive(),
 			ID:      stream.ID,
 			Alias:    aliasName,
@@ -296,7 +297,12 @@ func (c *Controller) StopStreamHandler(w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
-	if dto.ID == "" && len(dto.Alias) > 0 {
+	if dto.ID == "" && len(dto.Alias) == 0 {
+		c.sendError(w, err, http.StatusNotFound)
+		return
+	}
+
+	if len(dto.Alias) > 0 {
 		// redirect alias if used
 		newid, ok := c.alias[dto.Alias]
 		if ok {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -26,6 +26,10 @@ endpoints:
   list:
     enabled: true
     secret: macilaci
+listen:
+   - name: camera1
+     uri: rtp://user:pass@host/camera/123
+     enabled: false
 ```
 * enabled - false by default - boolean that indicates if the given endpoint is enabled or not
 * secret - empty by default - string which will be the secret in the JWT token
@@ -47,6 +51,10 @@ endpoints:
   list:
     enabled: true
     secret: macilaci
+listen:
+   - name: camera1
+     uri: rtp://user:pass@host/camera/123
+     enabled: false
 ```
 
 In this example everyone can start a stream and fetch video chunks if they know the id of the video, but only users with macilaci secret will be able to access the stop and list endpoints. 
@@ -89,6 +97,7 @@ Response:
 
 Simple static file serving which is used when fetching chunks of `HLS`. This will be called by the client (browser) to fetch the chunks of the stream based on the given `index.m3u8`.
 Note that authentication will also be checked when accessing the files via this endpoint. Therefore for maximum performance you can turn off JWT authentication but it is not recommended at all.
+The id value can either be the uuid of the stream or the alias if available.
 
 ### GET /list
 
@@ -100,7 +109,14 @@ Response:
     {
         "running": true,
         "uri": "/stream/9f4fa8eb-98c0-4ef6-9b89-b115d13bb192/index.m3u8",
-        "id": "9f4fa8eb-98c0-4ef6-9b89-b115d13bb192"
+        "id": "9f4fa8eb-98c0-4ef6-9b89-b115d13bb192",
+        "alias": "9f4fa8eb-98c0-4ef6-9b89-b115d13bb192"
+    },
+    {
+        "running": false,
+        "uri": "/stream/camera1/index.m3u8",
+        "id": "8ab9a89c-8271-4c89-97b7-c91372f4c1b0",
+        "alias": "camera1"
     }
 ]
 ``` 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -27,7 +27,7 @@ endpoints:
     enabled: true
     secret: macilaci
 listen:
-   - name: camera1
+   - alias: camera1
      uri: rtp://user:pass@host/camera/123
      enabled: false
 ```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -52,7 +52,7 @@ endpoints:
     enabled: true
     secret: macilaci
 listen:
-   - name: camera1
+   - alias: camera1
      uri: rtp://user:pass@host/camera/123
      enabled: false
 ```
@@ -77,11 +77,14 @@ More commands around docker at [debugging](../debugging#Docker)
 Starts the transcoding of the given stream. You have to pass URI format with rtsp procotol. 
 The respond should be considered the subpath for the video player to call.
 So if your applicaiton is `myapp.com` then you should call `myapp.com/stream/host/index.m3u8` in your video player.
-The reason for this is to remain flexible regarding useability. 
+The reason for this is to remain flexible regarding useability. The alias value is optional.
 
 Requires payload:
 ```js
-{ "uri": "rtsp://username:password@host" }
+{ 
+    "uri": "rtsp://username:password@host",
+    "alias": "camera1"
+}
 ```
 
 Response:
@@ -89,7 +92,8 @@ Response:
 { 
     "uri": "/stream/id/index.m3u8",
     "running": true,
-    "id": "id"
+    "id": "id",
+    "alias": "camera1"
 }
 ```
 
@@ -123,12 +127,14 @@ Response:
 
 ### POST /stop
 
-Endpoint used for stopping and removing a stream from the stored list.
+Endpoint used for stopping and removing a stream from the stored list. Either include an ID or Alias value to identify the stream. 
+In the event both values are provided, the ID will be used.
 
 Requires payload:
 ```js
 { 
-    "id": "40b1cc1b-bf19-4b07-8359-e934e7222109"
+    "id": "40b1cc1b-bf19-4b07-8359-e934e7222109",
+    "alias": "camera1",
     "remove": true, // optional - indicates if stream should be removed as well from list or not
     "wait": false // optional - indicates if the call should wait for the stream to stop
 }

--- a/main.go
+++ b/main.go
@@ -20,8 +20,7 @@ func main() {
 	core.SetupLogger(config)
 	fileServer := http.FileServer(http.Dir(config.StoreDir))
 	router := httprouter.New()
-	listen := config.EndpointYML.Listen
-	controllers := core.NewController(config, fileServer, listen)
+	controllers := core.NewController(config, fileServer)
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/main.go
+++ b/main.go
@@ -20,7 +20,8 @@ func main() {
 	core.SetupLogger(config)
 	fileServer := http.FileServer(http.Dir(config.StoreDir))
 	router := httprouter.New()
-	controllers := core.NewController(config, fileServer)
+	listen := config.EndpointYML.Listen
+	controllers := core.NewController(config, fileServer, listen)
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -40,6 +41,7 @@ func main() {
 		router.POST("/stop", controllers.StopStreamHandler)
 		logrus.Infoln("stop endpoint enabled | MainProcess")
 	}
+
 	done := controllers.ExitPreHook()
 	handler := cors.AllowAll().Handler(router)
 	if config.CORS.Enabled {


### PR DESCRIPTION
Added "listen" to the configuration as preloaded sources, allowing for an instance to be stopped and restarted with the same line up. In the yaml file, there is a new array section called "listen". These entries do not start streaming immediately by design, but do show up in the /list command as not running. The first request for a preload source will cause it to be started. This was to compliment the existing janitor that stops streams no longer in use, but restarts them when the clients return.

Added aliases to preconfigured sources, allowing a consistent URL to the stream even if the instance is restarted. This alters the /list results to show the alias URL instead of the UUID URL. When the /stream

The documentation has also been updated to reflect the changes made.

I am new to Go just for this pull request, so apologies if my code is unclean.