### PR TITLE
Add JWT StandardClaim validation

### DIFF
--- a/core/auth/jwt.go
+++ b/core/auth/jwt.go
@@ -19,11 +19,7 @@ type JWT interface {
 // Claim describes the claim for the token
 type Claim struct {
 	Secret string `json:"secret"`
-}
-
-// Valid shows if the claim is valid or not
-func (c Claim) Valid() error {
-	return nil
+    jwt.StandardClaims
 }
 
 // JWTProvider implements the validate method


### PR DESCRIPTION
This will add basic JWT validation, specifically it will validate the standard time-based claims "exp, iat, nbf". If any of these claims are not present, the token will still be considered valid. As a result, this shouldn't break any minimalist or non-standard implementations of JWT, while still enabling basic JWT auth validation based on standard claim implementations.

See https://pkg.go.dev/github.com/dgrijalva/jwt-go#StandardClaims.Valid

Also used in an example https://pkg.go.dev/github.com/dgrijalva/jwt-go#example-ParseWithClaims-CustomClaimsType
