### PR TITLE
Update to streamer 1.0.3, fixing audio issues with chromecast

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,7 @@
 
 [[constraint]]
   name = "github.com/riltech/streamer"
-  version = "1.0.1"
+  version = "1.0.3"
 
 [[constraint]]
   name = "github.com/kelseyhightower/envconfig"


### PR DESCRIPTION
Upstream changes resolve an audio flag inversion, and ensures that an audio stream exists (which is required by Chromecast devices)